### PR TITLE
Adding Sayna.ai, a self-hosted voice layer for AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@
 - [Wazo](https://wazo-platform.org) - VoIP API platform built on top of Asterisk, Kamailio and RTPEngine.
 - [jambonz](https://www.jambonz.org) - Open source CPaaS built for communications service providers.
 - [IVOZ Provider](https://github.com/irontec/ivozprovider) - Multitenant solution for VoIP telephony providers.
+- [Sayna](https://github.com/SaynaAI/sayna) - Real-time speech infrastructure for voice AI with WebSocket streaming, SIP telephony and pluggable STT/TTS providers.
 
 ### Billing
 


### PR DESCRIPTION
Adding [Sayna.ai](https://github.com/SaynaAI/sayna), which is a Rust-based self-hosted voice infrastructure for AI Agents. It handles everything that relates to the voice, like STT, TTS, SIP Telephony, Noise Suppression, TURN Taking, and nearly all providers for the voice. It is a great addition to the list, and a great way to get started with voice AI agents.