### PR TITLE
Add natcheck to STUN/TURN

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@
 
 - [coturn](https://github.com/coturn/coturn) - Fully featured TURN/STUN server supporting multiple platforms.
 - [eturnal](https://eturnal.net/) - Modern and scalable STUN/TURN server written in Erlang.
+- [natcheck](https://github.com/1mb-dev/natcheck) - NAT type diagnosis CLI. Probes STUN servers, classifies mapping behaviour per RFC 5780, and reports a WebRTC direct-P2P forecast.
 - [STUNTMAN](https://github.com/jselbie/stunserver) - RFC compliant open source STUN implementation.
 
 


### PR DESCRIPTION
Adds [natcheck](https://github.com/1mb-dev/natcheck) to `STUN/TURN` — a STUN-based NAT type diagnosis CLI. Inserted alphabetically between `eturnal` and `STUNTMAN`.