### PR TITLE
Add Peerix to JavaScript libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@
 - [sipML5](https://www.doubango.org/sipml5) - Open source JavaScript SIP client with WebRTC media stack.
 - [simple-peer](https://github.com/feross/simple-peer) - WebRTC video, voice, and data channels abstraction for Node.js and the browser.
 - [Netflux](https://github.com/coast-team/netflux) - Isomorphic JavaScript peer to peer transport API for client and server.
+- [Peerix](https://github.com/peerix-dev/peerix) - WebRTC library with pluggable signalling drivers (NATS, WebSocket, BroadcastChannel) and a single peer connection multiplexing media and data channels. TypeScript-first.
 - [PeerJS](https://peerjs.com) - Data and media peer-to-peer connection API implemented over WebRTC.
 - [Socio](https://github.com/Rolands-Laucis/Socio) - A WebSocket Real-Time Communication (RTC) API framework. Realtime Front-end, Back-end reactivity.
 


### PR DESCRIPTION
Adds Peerix, an open-source JavaScript/TypeScript WebRTC library.

It sits alongside simple-peer and PeerJS in the JS libraries section, with a different angle: signalling is implemented as a pluggable driver (NATS, MQTT, Socket.IO, SSE, Supabase, Centrifuge, BroadcastChannel, in-memory, or custom), so the peer code stays the same when the transport changes.

- Repo: https://github.com/peerix-dev/peerix
- Site: https://peerix.dev/
- Live sandbox: https://v48.livecodes.io/?x=id/j72zrf6uvqc&embed=true&mode=result
- Licence: Apache-2.0

It's actively maintained (v0.4.0), TypeScript-first, with zero runtime dependencies.
Happy to adjust the description or move the entry if you'd prefer it in a different section.