### PR TITLE
Add icey to C/C++ Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@
 - [PJSIP](https://www.pjsip.org) - Multi-protocol RTC library written in C.
 - [eXosip](http://savannah.nongnu.org/projects/exosip) - eXtended osip is a mature C library for abstracting the SIP protocol.
 - [libdatachannel](https://github.com/paullouisageneau/libdatachannel) - Standalone WebRTC DataChannels C++ implementation.
+- [icey](https://github.com/nilstate/icey) - C++20 WebRTC media runtime with FFmpeg pipeline, Symple signalling, and RFC 5766 TURN.
 - [libSRTP](https://github.com/cisco/libsrtp) - Secure Real-time Transport Protocol (SRTP) library for C.
 - [usrsctp](https://github.com/sctplab/usrsctp) - Portable Stream Control Transmission Protocol (SCTP) user-land stack.
 - [rawrtc](https://github.com/rawrtc/rawrtc) - WebRTC and ORTC library with a small footprint.


### PR DESCRIPTION
icey is a C++20 WebRTC media runtime: capture, encode, transport, signalling, and RFC 5766 TURN in one toolkit. Built on libdatachannel for transport and FFmpeg for media. CMake-native, system OpenSSL, no Chromium toolchain.

Fits alongside libdatachannel, rawrtc, and Open WebRTC Toolkit in the existing C/C++ Libraries section.

- Repo: https://github.com/nilstate/icey
- Homepage: https://0state.com/icey
- License: LGPL-2.1+