### PR TITLE
Add webrtc-leak-check to JavaScript Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@
 - [simple-peer](https://github.com/feross/simple-peer) - WebRTC video, voice, and data channels abstraction for Node.js and the browser.
 - [Netflux](https://github.com/coast-team/netflux) - Isomorphic JavaScript peer to peer transport API for client and server.
 - [PeerJS](https://peerjs.com) - Data and media peer-to-peer connection API implemented over WebRTC.
+- [webrtc-leak-check](https://github.com/CodeWithEhtisham/webrtc-leak-check) - Zero-dependency TypeScript library for detecting WebRTC IP address leaks, with RFC 8445 candidate parsing and host/srflx/relay classification.
 - [Socio](https://github.com/Rolands-Laucis/Socio) - A WebSocket Real-Time Communication (RTC) API framework. Realtime Front-end, Back-end reactivity.
 
 ### C/C++ Libraries


### PR DESCRIPTION
Adds [webrtc-leak-check](https://github.com/CodeWithEhtisham/webrtc-leak-check) to the JavaScript Libraries section.

It's a zero-dependency TypeScript library that detects WebRTC IP address leaks from the browser: gathers ICE candidates across multiple STUN providers (Cloudflare, Google, Twilio), parses them per RFC 8445 (no regex scraping), classifies host/srflx/relay candidate types, and handles compressed IPv6. Ships with unit tests (node:test) and documents its limitations honestly (no TURN/relay probing).

Disclosure: I'm the author of the library.

Checklist:
- [x] One suggestion per pull request
- [x] Format `- [PACKAGE](LINK) - DESCRIPTION.`
- [x] Description short, ends with a full stop
- [x] Not a commercial product (MIT-licensed open source)