### PR TITLE
Add 'Clients' section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   - [Deployment](#deployment)
   - [Web/API Interfaces](#webapi-interfaces)
   - [Billing](#billing)
+  - [Clients](#clients)
 - [Developer Resources](#developer-resources)
   - [Tutorials](#tutorials)
   - [JavaScript Libraries](#javascript-libraries)
@@ -107,6 +108,10 @@
 - [A2Billing](http://www.asterisk2billing.org) - Billing system for Asterisk for multiple applications.
 - [PyFreeBilling](https://github.com/mwolff44/pyfreebilling) - Wholesale billing platform for Kamailio and FreeSWITCH.
 
+
+## Clients
+
+- [Browser-Phone](https://github.com/Siperb/Browser-Phone) - A fully featured browser-based WebRTC SIP phone for Asterisk.
 
 ## Developer Resources
 


### PR DESCRIPTION
Adds a new **Clients** section to the README, listing [Browser-Phone](https://github.com/Siperb/Browser-Phone) - an open-source (AGPL-3.0) browser-based WebRTC SIP phone for Asterisk.

None of the existing categories quite fit a full end-user client application (Web/API Interfaces covers backend platforms, JavaScript Libraries covers importable libraries rather than full apps), so this proposes a new top-level category per the "new categories... welcome" note in CONTRIBUTING.md. Happy to fold it into a different section if you'd prefer.

Disclosure: I'm affiliated with Siperb, which maintains Browser-Phone.