### PR TITLE
Add rtcStats to Operations/Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@
 - [HOMER](https://github.com/sipcapture/homer) - Multi-protocol capturing and monitoring framework for RTC.
 - [WebRTC Troubleshooter](https://github.com/webrtc/testrtc) - Self-hosted one stop client-side WebRTC troubleshooter.
 - [Trickle ICE](https://webrtc.github.io/samples/src/content/peerconnection/trickle-ice) - Exposes client-side NAT traversal debug data.
+- [rtcStats](https://github.com/rtcstats/rtcstats) - Open-source WebRTC observability and debugging: getStats capture, session dump analysis, and quality metrics (hosted option at rtcstats.com).
 - [SIP3](https://sip3.io) - VoIP & RTC traffic monitoring and analysis platform.
 
 ### Testing


### PR DESCRIPTION
Adds rtcStats to the Monitoring subsection: an open-source WebRTC observability and debugging toolkit (getStats + API-trace capture, session analysis, quality metrics), with a hosted option at rtcstats.com. The section has SIP/RTP monitors but no WebRTC-observability entry yet.

Disclosure: I'm one of the maintainers of rtcStats.