### PR TITLE
Add sip-exporter to monitoring tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 ### Monitoring
 
 - [sngrep](https://github.com/irontec/sngrep) - Terminal based SIP flow viewer.
+- [sip-exporter](https://github.com/aibudaevv/sip-exporter) - Open-source eBPF sensor exporting Prometheus metrics and Grafana dashboards for host-observed IPv4/UDP SIP and correlated RTP/RTCP.
 - [sipgrep](https://github.com/sipcapture/sipgrep) - Console tool for sniffing, capturing and exploring SIP traffic.
 - [rtpbreak](https://github.com/Naishy/rtpsplit) - Detect, reconstruct and analyze RTP sessions.
 - [HOMER](https://github.com/sipcapture/homer) - Multi-protocol capturing and monitoring framework for RTC.


### PR DESCRIPTION
Adds sip-exporter to Operations / Monitoring.

sip-exporter is an open-source eBPF sensor maintained by me. It exports Prometheus metrics and Grafana dashboards for IPv4/UDP SIP and correlated RTP/RTCP observed on a Linux host.

Stable release:
https://github.com/aibudaevv/sip-exporter/releases/tag/v1.11.0

Maintainer disclosure: I maintain sip-exporter and am submitting my own project.
